### PR TITLE
Revert "Suggested fix to Sec. 4.2 to make it clear that ODC_BY is not ShareAlike"

### DIFF
--- a/texts/odc-by.md
+++ b/texts/odc-by.md
@@ -231,10 +231,11 @@ Your complying with the following conditions of use. These are important
 conditions of this License, and if You fail to follow them, You will be
 in material breach of its terms.
 
-4.2 Notices. If You Publicly Convey this Database, including as part of a
-Derivative Database or as part of a Collective Database, then You must:
+4.2 Notices. If You Publicly Convey this Database, any Derivative
+Database, or the Database as part of a Collective Database, then You
+must: 
 
-  a. Indicate the Database is licensed under the terms of this License;
+  a. Do so only under the terms of this License;
 
   b. Include a copy of this License or its Uniform Resource Identifier (URI)
   with the Database or Derivative Database, including both in the


### PR DESCRIPTION
This reverts commit 4641eebdcc61513cd680ec11736d0f2c2fe82757.

The text for a particular version of the license can't change, and
changing it needs more consultation than a commit on GitHub.

I left the trailing \n fix in, as that is not a change to the text.

I am taking no stance on the merits of the suggested change, but that needs to be discussed as part of releasing a new version of the license.